### PR TITLE
Fixed enabling of start button

### DIFF
--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -57,7 +57,7 @@ namespace PiBootstrapper
 
             bool isEmpty = (driveComboBox.SelectedIndex == -1
                 || nameTextBox.Text.Length == 0
-                || userTextBox.Text.Length == 0
+                || (typeComboBox.SelectedIndex == 1 && userTextBox.Text.Length == 0)
                 || passwordTextBox.Text.Length == 0
                 || passwordTextBox2.Text.Length == 0);
 


### PR DESCRIPTION
Start button relied on username box not being empty, even though this is not required for personal networks.